### PR TITLE
Update karma-should to reflect changes introduced to should.js 7.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # karma-should
 
-[should](https://github.com/tj/should.js) for [karma](http://karma-runner.github.io).
+[should](https://github.com/shouldjs/should.js) for [karma](http://karma-runner.github.io).
 
 
 ## Status
@@ -25,7 +25,10 @@ Add `should` to `frameworks` and `karma-should` to `plugins` keys in your karma 
 ```js
 module.exports = function(config) {
   config.set({
+    // include 'should' as the assertion library used by 'mocha' (a testing framework), for example
     frameworks: ['mocha', 'should'],
+
+    // by default karma includes 'karma-*', so the next statement is only necessary for custom plugin inclusion
     plugins: ['karma-should']
   });
 };

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var pattern = function(file) {
  */
 
 var framework = function(files) {
-  files.unshift(pattern(path.resolve(require.resolve('should'), '../../should.js')));
+  files.unshift(pattern(path.resolve(require.resolve('should'), '../should.js')));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/seegno/karma-should",
   "peerDependencies": {
     "karma": ">=0.10.9",
-    "should": "*"
+    "should": ">=7.0.0"
   },
   "devDependencies": {
     "github-changes": "0.0.16"


### PR DESCRIPTION
should.js changed the path to the main file in their package.json. This made the path-building routine in karma-should fail to return the valid path and thus karma failed to include the should.js assertion library, when running tests.

Besides adapting the appropriate files to overcome this issue I took the liberty to enhance the README.md by updating the path to should.js and add comments to describe the configuration.

:)
